### PR TITLE
chore: refresh copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2011-2021 Vitaly Kravtsov (in4lio@gmail.com)
+Copyright (c) 2011-2026 Vitaly Kravtsov (in4lio@gmail.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The MIT notice now reflects the project's active maintenance through 2026.
