### PR TITLE
ci: publish releases to PyPI with trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,68 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and verify distributions
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name }}
+      - name: Set up Python 3.14
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+      - name: Verify release tag matches package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: >-
+          python -c "import os, pathlib, tomllib;
+          version = tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'];
+          tag = os.environ['RELEASE_TAG'].removeprefix('v');
+          assert tag == version,
+          f'release tag {tag!r} does not match package version {version!r}'"
+      - name: Install release tools
+        run: python -m pip install build pytest "setuptools>=77" twine wheel
+      - name: Build wheel and sdist
+        run: python -m build
+      - name: Check distribution metadata
+        run: python -m twine check --strict dist/*
+      - name: Test exact release distributions
+        env:
+          YUPP_DISTRIBUTIONS: ${{ github.workspace }}/dist
+        run: python -m pytest -q
+      - name: Upload exact release distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-distributions
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish distributions
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/p/yupp
+    permissions:
+      id-token: write
+    steps:
+      - name: Download exact release distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-distributions
+          path: dist
+      - name: Publish to PyPI with attestations
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![yupp logo](doc/pic/logo.png)](doc/README.md)
+[![yupp logo][logo]][language guide]
 
 # yupp
 
@@ -53,12 +53,11 @@ int main(void)
 }
 ```
 
-Documentation starts with the [language guide](doc/README.md). The
-[built-in reference](doc/builtin.md), [Python integration guide](doc/python.md),
-[evaluator migration guide](doc/yueval-migration.md), and
-[language evolution note](doc/language-evolution.md) cover specialized topics.
+Documentation starts with the [language guide]. The [built-in reference],
+[Python integration guide], [evaluator migration guide], and
+[language evolution note] cover specialized topics.
 Runnable inputs and their checked-in outputs are indexed in
-[tracked examples](eg/README.md).
+[tracked examples].
 
 ## Direct Python scripts
 
@@ -89,7 +88,7 @@ and a script run by a different interpreter environment from the one where
 `yupp` is installed. In particular, `-S` disables `site` and the `.pth` hook
 that registers the codec.
 
-More detail is in [Macros in Python](doc/python.md).
+More detail is in [Macros in Python][Python integration guide].
 
 ## Security and migration
 
@@ -97,9 +96,9 @@ Process only trusted input. Macro expressions and infix `{ Python }`
 expressions can execute Python, `($import ...)` can execute imported Python
 files, and `.yuconfig` files are Python scripts. `yupp` is not a sandbox.
 
-The [migration guide](doc/yueval-migration.md) covers Python 3 project updates,
-cache regeneration, evaluator scope and conditional changes, the optional
-dynamic-scope warning, and the full compatibility table.
+The [migration guide][evaluator migration guide] covers Python 3 project
+updates, cache regeneration, evaluator scope and conditional changes, the
+optional dynamic-scope warning, and the full compatibility table.
 
 ## Development
 
@@ -116,7 +115,7 @@ The wheel is the installation artifact used by clean-environment tests. The
 repository keeps generated examples next to their source templates; update a
 template first, regenerate with the current engine, and review both diffs.
 
-The bundled [Sublime Text files](sublime_text/README.md) remain a manually
+The bundled [Sublime Text files] remain a manually
 installed editor integration.
 
 The repository has one public documentation tree:
@@ -133,4 +132,14 @@ ignored and must not be committed.
 
 ## License
 
-See [LICENSE](LICENSE).
+See [LICENSE].
+
+[logo]: https://raw.githubusercontent.com/in4lio/yupp/master/doc/pic/logo.png
+[language guide]: https://github.com/in4lio/yupp/blob/master/doc/README.md
+[built-in reference]: https://github.com/in4lio/yupp/blob/master/doc/builtin.md
+[Python integration guide]: https://github.com/in4lio/yupp/blob/master/doc/python.md
+[evaluator migration guide]: https://github.com/in4lio/yupp/blob/master/doc/yueval-migration.md
+[language evolution note]: https://github.com/in4lio/yupp/blob/master/doc/language-evolution.md
+[tracked examples]: https://github.com/in4lio/yupp/blob/master/eg/README.md
+[Sublime Text files]: https://github.com/in4lio/yupp/blob/master/sublime_text/README.md
+[LICENSE]: https://github.com/in4lio/yupp/blob/master/LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 keywords = ["preprocessor", "macros", "code-generation"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -4,17 +4,34 @@ from tests.conftest import REPO_ROOT
 
 
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+PUBLISH_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish.yml"
 
 ACTION_PINS = {
     "actions/checkout": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
     "actions/setup-python": "a309ff8b426b58ec0e2a45f0f869d46889d02405",
     "actions/upload-artifact": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
     "actions/download-artifact": "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+    "pypa/gh-action-pypi-publish": "cef221092ed1bacb1cc03d23a2d87d1d172e277b",
 }
 
 
-def _workflow_source():
-    return WORKFLOW.read_text(encoding="utf8")
+def _workflow_source(path=WORKFLOW):
+    return path.read_text(encoding="utf8")
+
+
+def _assert_actions_are_pinned(source):
+    uses_lines = [line.strip() for line in source.splitlines() if "uses:" in line]
+    pinned = re.compile(
+        r"^uses: ([a-z0-9_-]+/[a-z0-9_-]+)@([0-9a-f]{40}) "
+        r"# (v[^ ]+|release/v[0-9]+)$"
+    )
+
+    assert uses_lines
+    for line in uses_lines:
+        match = pinned.fullmatch(line)
+        assert match is not None, f"action is not pinned with a tag comment: {line}"
+        action, revision, _tag = match.groups()
+        assert ACTION_PINS[action] == revision
 
 
 def test_only_github_actions_is_the_active_ci_surface():
@@ -38,18 +55,7 @@ def test_ci_has_read_only_permissions_and_safe_event_inputs():
 
 
 def test_all_actions_are_pinned_to_reviewed_full_commit_shas():
-    source = _workflow_source()
-    uses_lines = [line.strip() for line in source.splitlines() if "uses:" in line]
-    pinned = re.compile(
-        r"^uses: ([a-z0-9_-]+/[a-z0-9_-]+)@([0-9a-f]{40}) # (v[^ ]+)$"
-    )
-
-    assert uses_lines
-    for line in uses_lines:
-        match = pinned.fullmatch(line)
-        assert match is not None, f"action is not pinned with a tag comment: {line}"
-        action, revision, _tag = match.groups()
-        assert ACTION_PINS[action] == revision
+    _assert_actions_are_pinned(_workflow_source())
 
 
 def test_ci_reuses_one_exact_distribution_set_for_all_artifact_gates():
@@ -72,3 +78,42 @@ def test_supported_and_advisory_python_matrices_are_explicit():
     assert "continue-on-error: true" in source
     assert "if: ${{ always() }}" in source
     assert " -n " not in source
+
+
+def test_publish_workflow_uses_release_gate_and_trusted_publishing():
+    source = _workflow_source(PUBLISH_WORKFLOW)
+    event_source = source.split("on:\n", 1)[1].split("\npermissions:\n", 1)[0]
+
+    assert event_source == "  release:\n    types: [published]\n"
+    assert "permissions:\n  contents: read\n" in source
+    assert source.count("permissions:") == 2
+    assert source.count("id-token: write") == 1
+    assert "environment:\n      name: pypi" in source
+    assert "url: https://pypi.org/p/yupp" in source
+    assert "secrets." not in source
+
+
+def test_publish_workflow_separates_build_from_oidc_publish_job():
+    source = _workflow_source(PUBLISH_WORKFLOW)
+
+    build_source, publish_source = source.split("\n  publish:\n", 1)
+    assert "python -m build" in build_source
+    assert "python -m twine check --strict dist/*" in build_source
+    assert "RELEASE_TAG: ${{ github.event.release.tag_name }}" in build_source
+    assert ".removeprefix('v')" in build_source
+    assert "does not match package version" in build_source
+    assert "YUPP_DISTRIBUTIONS: ${{ github.workspace }}/dist" in build_source
+    assert build_source.index("python -m build") < build_source.index(
+        "python -m pytest"
+    )
+    assert "id-token: write" not in build_source
+    assert "needs: build" in publish_source
+    assert "id-token: write" in publish_source
+    assert "python -m build" not in publish_source
+    assert source.count("name: release-distributions") == 2
+    assert "persist-credentials: false" in source
+    assert "ref: ${{ github.event.release.tag_name }}" in build_source
+
+
+def test_publish_actions_are_pinned_to_reviewed_full_commit_shas():
+    _assert_actions_are_pinned(_workflow_source(PUBLISH_WORKFLOW))

--- a/tests/test_no_legacy.py
+++ b/tests/test_no_legacy.py
@@ -327,7 +327,11 @@ def test_migration_details_have_one_canonical_guide():
         encoding="utf8"
     ).lower()
 
-    assert "[migration guide](doc/yueval-migration.md)" in readme
+    assert "[migration guide][evaluator migration guide]" in readme
+    assert (
+        "[evaluator migration guide]: "
+        "https://github.com/in4lio/yupp/blob/master/doc/yueval-migration.md"
+    ) in readme
     assert "when upgrading from the python 2-compatible release" not in readme
     for required in (
         "## security boundary",

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -5,6 +5,7 @@ import email.parser
 import hashlib
 import os
 from pathlib import Path
+import re
 import shutil
 import stat
 import subprocess
@@ -145,9 +146,21 @@ def test_metadata_is_static_and_artifacts_are_complete(distributions):
     assert metadata["Version"] == "2.0rc1"
     assert metadata["Requires-Python"] == ">=3.11"
     assert metadata.get_all("Requires-Dist") is None
+    assert "Development Status :: 4 - Beta" in metadata.get_all("Classifier")
+    description = metadata.get_payload()
     assert b"yupp = yupp.__main__:main" in payload[f"{dist_info}/entry_points.txt"]
     assert b"Root-Is-Purelib: true" in payload[f"{dist_info}/WHEEL"]
     assert b"Tag: py3-none-any" in payload[f"{dist_info}/WHEEL"]
+
+    reference_targets = re.findall(
+        r"^\[[^]]+\]:\s+(\S+)$", description, re.MULTILINE
+    )
+    inline_targets = re.findall(r"\]\(([^)\s]+)", description)
+    assert reference_targets
+    assert all(
+        target.startswith("https://")
+        for target in (*reference_targets, *inline_targets)
+    )
 
     assert names.count("yupp.pth") == 1
     recorded_names = _assert_wheel_record(payload)


### PR DESCRIPTION
## Summary

yupp releases can now publish wheel and sdist artifacts to PyPI without a
long-lived API token. Publication remains an explicit operation: only a
published GitHub Release starts the workflow, and its tag must match the
package version before any artifact is built.

The release pipeline keeps the OIDC permission in a separate publish job,
tests the exact distributions it uploads, pins every third-party action to a
reviewed commit, and emits PyPI attestations. The 2.0rc1 metadata now reports a
prerelease development status, while the long description uses absolute links
that render correctly outside GitHub.

## Validation

- `255 passed` against the final wheel and sdist
- clean isolated wheel/sdist build
- `twine check --strict` passed for both artifacts
- publish workflow parses as YAML and its release/OIDC/artifact contracts are
  covered by regression tests
- the tag guard accepts `2.0rc1` and `v2.0rc1`, and rejects a mismatched version

## Release setup

Before publishing the first release, add a PyPI Trusted Publisher for the
existing `yupp` project with these exact values:

- Owner: `in4lio`
- Repository: `yupp`
- Workflow: `publish.yml`
- Environment: `pypi`

Create the matching GitHub environment named `pypi`, merge this PR, then
publish a prerelease whose tag is `2.0rc1` or `v2.0rc1`. No PyPI token or
repository secret is required.

## Post-Deploy Monitoring & Validation

- Owner/window: repository maintainer during the first release and for 30
  minutes afterward.
- Healthy signals: both jobs in `Publish to PyPI` are green; PyPI lists
  `2.0rc1` with exactly one wheel and one sdist; provenance attestations are
  present; a clean environment installs `yupp==2.0rc1` and
  `python -m yupp --version` succeeds.
- Failure signals: tag/version mismatch, Trusted Publisher/OIDC rejection,
  missing artifact, failed clean install, or unexpected package contents.
- Mitigation: stop before retrying, confirm whether PyPI already accepted the
  immutable version, then fix the workflow/configuration. Yank a bad release
  and issue a new release candidate rather than attempting to overwrite it.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
